### PR TITLE
feat(ngrx-firebase): add operator to handle empty changes from sdk10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngflex-libs",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "license": "MIT",
   "description": "NGFlex ngrx, firebase and js libraries",
   "packageManager": "yarn@4.1.0",

--- a/packages/ngrx-firebase/lib/models/action-types.model.ts
+++ b/packages/ngrx-firebase/lib/models/action-types.model.ts
@@ -11,11 +11,13 @@ export type ActionCreatorWithParentIdProp = ActionCreator<string, (props: {
 
 export type ActionCreatorWithNoProp = ActionCreator<string>;
 
+export type ActionCreatorType = ActionCreatorWithNoProp | ActionCreatorWithParentIdProp | ActionCreatorWithParentIdPropAndPayloadProp;
+
 export type ActionTypes = {
-  load?: ActionCreatorWithNoProp | ActionCreatorWithParentIdProp | ActionCreatorWithParentIdPropAndPayloadProp,
-  loadNoResults?: ActionCreatorWithNoProp | ActionCreatorWithParentIdProp | ActionCreatorWithParentIdPropAndPayloadProp,
-  loadFail?: ActionCreatorWithNoProp | ActionCreatorWithParentIdProp | ActionCreatorWithParentIdPropAndPayloadProp,
-  addMany?: ActionCreatorWithNoProp | ActionCreatorWithParentIdProp | ActionCreatorWithParentIdPropAndPayloadProp,
-  upsertMany?: ActionCreatorWithNoProp | ActionCreatorWithParentIdProp | ActionCreatorWithParentIdPropAndPayloadProp,
-  removeMany?: ActionCreatorWithNoProp | ActionCreatorWithParentIdProp | ActionCreatorWithParentIdPropAndPayloadProp,
+  load?: ActionCreatorType,
+  loadNoResults?: ActionCreatorType,
+  loadFail?: ActionCreatorType,
+  addMany?: ActionCreatorType,
+  upsertMany?: ActionCreatorType,
+  removeMany?: ActionCreatorType,
 };

--- a/packages/ngrx-firebase/lib/operators/wrap-collection-changes.operator.spec.ts
+++ b/packages/ngrx-firebase/lib/operators/wrap-collection-changes.operator.spec.ts
@@ -21,6 +21,25 @@ describe('wrapCollectionChange', () => {
   });
 
   describe('when handleEmptyCollections is set to true', () => {
+    it('should handle empty collections considering default option value to true', (done) => {
+      const queryMock: any = {};
+      const actions = {
+        loadNoResults: jest.fn().mockName('loadNoResults'),
+      } as any;
+      const ngrxOptions = { otherOption: 'value' } as any;
+
+      (fireStore.collectionData as jest.Mock).mockReturnValue(of([]));
+      (fireStore.collectionChanges as jest.Mock).mockReturnValue(of([]));
+      (mapDocumentActionToNgrxAction as jest.Mock).mockImplementation(() => () => of([]));
+
+      wrapCollectionChange(queryMock, actions, ngrxOptions).subscribe(() => {
+        expect(actions.loadNoResults).toHaveBeenCalled();
+        expect((mapDocumentActionToNgrxAction as jest.Mock)).toHaveBeenCalledWith(actions, ngrxOptions);
+
+        done();
+      });
+    });
+
     it('should handle empty collections', (done) => {
       const queryMock: any = {};
       const actions = {

--- a/packages/ngrx-firebase/lib/operators/wrap-collection-changes.operator.spec.ts
+++ b/packages/ngrx-firebase/lib/operators/wrap-collection-changes.operator.spec.ts
@@ -1,0 +1,113 @@
+import * as fireStore from '@angular/fire/firestore';
+import { of } from 'rxjs';
+
+import { wrapCollectionChange } from './wrap-collection-changes.operator';
+import { mapDocumentActionToNgrxAction } from './map-document-action-to-ngrx-action.operator';
+
+jest.mock('@angular/fire/firestore', () => ({
+  collectionChanges: jest.fn(),
+  collectionData: jest.fn(),
+}));
+
+jest.mock('./map-document-action-to-ngrx-action.operator', () => ({
+  mapDocumentActionToNgrxAction: jest.fn(),
+}));
+
+describe('wrapCollectionChange', () => {
+  beforeEach(() => {
+    (fireStore.collectionData as jest.Mock).mockReset();
+    (fireStore.collectionChanges as jest.Mock).mockReset();
+    (mapDocumentActionToNgrxAction as jest.Mock).mockReset();
+  });
+
+  describe('when handleEmptyCollections is set to true', () => {
+    it('should handle empty collections', (done) => {
+      const queryMock: any = {};
+      const actions = {
+        loadNoResults: jest.fn().mockName('loadNoResults'),
+      } as any;
+      const ngrxOptions = { otherOption: 'value' };
+      const mappingOptions = { handleEmptyCollections: true, ...ngrxOptions };
+
+      (fireStore.collectionData as jest.Mock).mockReturnValue(of([]));
+      (fireStore.collectionChanges as jest.Mock).mockReturnValue(of([]));
+      (mapDocumentActionToNgrxAction as jest.Mock).mockImplementation(() => () => of([]));
+
+      wrapCollectionChange(queryMock, actions, mappingOptions).subscribe(() => {
+        expect(actions.loadNoResults).toHaveBeenCalled();
+        expect((mapDocumentActionToNgrxAction as jest.Mock)).toHaveBeenCalledWith(actions, ngrxOptions);
+
+        done();
+      });
+    });
+
+    it('should handle non-empty collections', (done) => {
+      const queryMock: any = {};
+      const actions = {
+        loadNoResults: jest.fn().mockName('loadNoResults'),
+      } as any;
+      const ngrxOptions = { otherOption: 'value' };
+      const mappingOptions = { handleEmptyCollections: true, ...ngrxOptions };
+
+      const mockCollectionData = [{ id: 'doc1', data: 'sampleData' }];
+      const mockCollectionChange = { type: 'added', payload: mockCollectionData };
+      (fireStore.collectionData as jest.Mock).mockReturnValue(of(mockCollectionData));
+      (fireStore.collectionChanges as jest.Mock).mockReturnValue(of(mockCollectionChange));
+      (mapDocumentActionToNgrxAction as jest.Mock).mockImplementation(() => (source) => source);
+
+      wrapCollectionChange(queryMock, actions, mappingOptions).subscribe((result) => {
+        expect(actions.loadNoResults).not.toHaveBeenCalled();
+        expect((mapDocumentActionToNgrxAction as jest.Mock)).toHaveBeenCalledWith(actions, ngrxOptions);
+        expect(result).toEqual(mockCollectionChange);
+
+        done();
+      });
+    });
+
+    describe('when no "loadNoResults" action is defined', () => {
+      it('should directly process collection changes', (done) => {
+        const queryMock: any = {}; // Mock Query
+        const actions = {
+          create: jest.fn().mockName('createAction')
+        } as any;
+        const mappingOptions = { handleEmptyCollections: true };
+
+        const mockCollectionData = [{ id: 'doc1', data: 'sampleData' }];
+        const mockCollectionChange = { type: 'added', payload: mockCollectionData };
+
+        (fireStore.collectionChanges as jest.Mock).mockReturnValue(of(mockCollectionChange));
+        (mapDocumentActionToNgrxAction as jest.Mock).mockImplementation(() => (source) => source);
+
+        wrapCollectionChange(queryMock, actions, mappingOptions).subscribe((result) => {
+          expect(result).toEqual(mockCollectionChange);
+          expect(fireStore.collectionData).not.toHaveBeenCalled();
+
+          done();
+        });
+      });
+    });
+  });
+
+  describe('when handleEmptyCollections is set to false', () => {
+    it('should directly process collection changes', (done) => {
+      const queryMock: any = {}; // Mock Query
+      const actions = {
+        create: jest.fn().mockName('createAction')
+      } as any;
+      const mappingOptions = { handleEmptyCollections: false };
+
+      const mockCollectionData = [{ id: 'doc1', data: 'sampleData' }];
+      const mockCollectionChange = { type: 'added', payload: mockCollectionData };
+
+      (fireStore.collectionChanges as jest.Mock).mockReturnValue(of(mockCollectionChange));
+      (mapDocumentActionToNgrxAction as jest.Mock).mockImplementation(() => (source) => source);
+
+      wrapCollectionChange(queryMock, actions, mappingOptions).subscribe((result) => {
+        expect(result).toEqual(mockCollectionChange);
+        expect(fireStore.collectionData).not.toHaveBeenCalled();
+
+        done();
+      });
+    });
+  });
+});

--- a/packages/ngrx-firebase/lib/operators/wrap-collection-changes.operator.ts
+++ b/packages/ngrx-firebase/lib/operators/wrap-collection-changes.operator.ts
@@ -1,0 +1,31 @@
+import { collectionChanges, collectionData, Query, DocumentData } from '@angular/fire/firestore';
+import { switchMap, of } from 'rxjs';
+
+import { ActionTypes, ActionOptions, ActionCreatorWithNoProp } from '../models';
+import { mapDocumentActionToNgrxAction } from './map-document-action-to-ngrx-action.operator';
+
+export const wrapCollectionChange = <T>(
+  query: Query<T, DocumentData>,
+  actions: ActionTypes,
+  mappingOptions: Partial<ActionOptions<T>> & { handleEmptyCollections?: boolean },
+) => {
+  const { handleEmptyCollections = true, ...ngrxMappingOptions } = mappingOptions;
+
+  const collChangeStream = collectionChanges(query).pipe(
+    mapDocumentActionToNgrxAction<T>(actions, ngrxMappingOptions as Partial<ActionOptions<T>>),
+  );
+
+  if (handleEmptyCollections && !!actions.loadNoResults) {
+    return collectionData(query).pipe(
+      switchMap((data) => {
+        if (!data.length) {
+          return of((actions.loadNoResults as ActionCreatorWithNoProp)());
+        }
+
+        return collChangeStream;
+      }),
+    );
+  }
+
+  return collChangeStream;
+}


### PR DESCRIPTION
In SDK 10, firebase doesn't fire collection event when collection doesn't exist or is empty. We add a wrapper here to allow user to automatically pipe their documentChanges listener to relevant `loadNoResults` action.